### PR TITLE
Set up dev environment + document build/run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a plain Java project (JDK 21 is preinstalled on the VM). There is **no build
+system** (no Maven/Gradle, no `pom.xml`/`build.gradle`) and **no package manager**, so
+there are no dependencies to install. Compilation is done directly with `javac`.
+
+### Build & run
+
+The runnable, self-contained application is `src/Main.java` (default package):
+
+```bash
+javac -d out src/Main.java
+java -cp out Main
+```
+
+`out/` is git-ignored, so it is safe to use as the compile output directory.
+
+### Tests / lint
+
+There are no automated tests and no lint tooling configured in this repo.
+
+### Known caveat: the SkyShop sources do not compile
+
+`src/org/skypro/skyshop/App.java` and `src/basket/ProductBasket.java` reference a class
+`org.skypro.skyshop.product.Product` that does not exist. The only `Product` class is
+`src/product/Product.java`, which declares `package product;` and is empty (no
+constructor/fields/methods). The package declarations also do not match the directory
+layout. Compiling the whole tree therefore fails. This is a pre-existing **code defect**,
+not an environment/dependency problem — do not treat it as an environment setup issue.
+Only `src/Main.java` builds and runs cleanly.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this plain Java project and documents how to build/run it for future agents.

- The VM already has **JDK 21** installed. There is **no build system** (no Maven/Gradle) and **no package manager**, so there are no dependencies to install.
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section describing build/run commands and a known code defect.
- Configured a minimal, idempotent update script (`java -version`) since there is nothing to install.

## Verification

The self-contained app `src/Main.java` compiles and runs end-to-end:

```
javac -d out src/Main.java
java -cp out Main
```

Output:
```
Hello and welcome!i = 1
i = 2
i = 3
i = 4
i = 5
```

[build_and_run.log](https://cursor.com/agents/bc-bf570eaa-8bc6-4826-aa85-4c83295cacd1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_and_run.log)

## Known caveat (pre-existing code defect, not an environment issue)

`src/org/skypro/skyshop/App.java` and `src/basket/ProductBasket.java` reference a non-existent class `org.skypro.skyshop.product.Product` (the only `Product` class, `src/product/Product.java`, is empty and in package `product`), and package declarations don't match the directory layout. Compiling the whole tree therefore fails. Per the setup task I did not modify existing code; only `src/Main.java` builds/runs cleanly.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf570eaa-8bc6-4826-aa85-4c83295cacd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf570eaa-8bc6-4826-aa85-4c83295cacd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

